### PR TITLE
Missing `"` in the example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ resource "libvirt_domain" "domain" {
 }
 
 resource "salt_host" "example" {
-    host = "${libvirt_domain.domain.network_interface.0.addresses.0}
+    host = "${libvirt_domain.domain.network_interface.0.addresses.0}"
 }
 ```
 


### PR DESCRIPTION
There was a missing " when I went to use the example.